### PR TITLE
Fix Reference Error

### DIFF
--- a/ableton.coffee
+++ b/ableton.coffee
@@ -45,7 +45,7 @@ class Ableton
       .pipe(concat(onLoad(callback, @parseMode)))
 
   write: (xml, callback) ->
-    unless data
+    unless xml
       callback(new Error('No data to write'))
       return
 


### PR DESCRIPTION
Currently while writing a ALS file, the write method throws a ReferenceError as it tries to read `data` instead of `xml`.