### PR TITLE
Fixed a few bugs

### DIFF
--- a/ableton.coffee
+++ b/ableton.coffee
@@ -27,7 +27,8 @@ onLoad = (callback, parseMode) ->
       when 'xmlstring'
         callback(null, xml)
       when 'dom'
-        dom = cheerio.load(xml)
+        options = {xmlMode: true}
+        dom = cheerio.load(xml, options)
         callback(null, dom)
       when 'js'
         parser = new Parser(mergeAttrs: yes)
@@ -45,7 +46,7 @@ class Ableton
       .pipe(concat(onLoad(callback, @parseMode)))
 
   write: (xml, callback) ->
-    unless data
+    unless xml
       callback(new Error('No data to write'))
       return
 


### PR DESCRIPTION
The write function was throwing an error because it wanted var data and not var xml
&& 
Ableton was being rude when converting from xml back to als because entities were not capitalized. This is fixed when added a cheerio option: {xmlMode: true}